### PR TITLE
feat(site): add How You Improve section + homepage copy updates

### DIFF
--- a/src/app/(frontend)/(browse)/page.tsx
+++ b/src/app/(frontend)/(browse)/page.tsx
@@ -5,6 +5,7 @@ import {
   ValuePropSection,
   WhatYouGetEveryMonth,
 } from '@/components/layout/home'
+import { HowYouImprove } from '@/components/layout/home/how-you-improve'
 import { FeaturedMentorsSection } from '@/components/layout/home/featured-mentors'
 import { TestimonialsSection } from '@/components/layout/home/testimonials'
 import { Badge } from '@/components/ui/badge'
@@ -65,22 +66,22 @@ const faqs = [
   {
     question: 'What is Performix?',
     answer:
-      'Performix is a high-performance development platform built by D1/pro athletes and top experts—performance coaches, specialists, and experienced team coaches. You get paired with your own personal D1 mentor and gain access to elite tools: custom training, nutrition, mindset strategies, video breakdowns, recruiting support, and a proven system designed to accelerate your development.',
+      'Performix is changing the way serious hockey players develop by helping them unlock more of their full ability in games. You work 1-on-1 with a Division I mentor who analyzes your game, identifies what\'s limiting you, and builds a plan around the adjustments that will make the biggest difference. We combine mentorship, hockey IQ development, and mental performance work into one clear system built to move your game forward.',
   },
   {
     question: 'Who is Performix for?',
     answer:
-      'Performix is for driven hockey players (typically ages 13-18) looking to develop faster, train smarter, and reach the next level—whether that is prep, juniors, or Division 1.',
+      "Performix is for serious hockey players (typically 13–18) who know they're capable of more but aren't consistently showing it in games. It's built for players who want structured guidance, high-level mentorship, and a clear development path toward prep, junior, NCAA, or higher levels.",
   },
   {
     question: 'What do I get with Performix?',
     answer:
-      'Depending on your package, you get matched with a personal mentor and unlock full access to the Performix system—including custom development plans, biweekly Zoom calls, goal-setting support, private video feedback, and unlimited mentor access. You will also get the full course, nutrition tools, mindset strategies, and recruiting guidance tailored to your game.',
+      'What you receive depends on your package, but every athlete gets direct support from a Division I mentor, 1-on-1 video analysis and mental sessions, a personalized development plan, and full access to the Performix system and tools. Higher tiers include more sessions and deeper customization, but the focus is always the same: real in-game improvement.',
   },
   {
     question: 'How do I get started?',
     answer:
-      'Book a free Zoom call so we can learn about your goals and pair you with the right mentor. From there, you\'ll unlock your tools, schedule your sessions, and start making real progress.',
+      "Book a free strategy call. We'll learn about your goals, situation, and development needs. If it's a fit, we'll match you with the right mentor and package to move your game forward.",
   },
   {
     question: "What's coming next on Performix?",
@@ -147,10 +148,10 @@ export default function HomePage() {
                   </span>
                 </h1>
                 <p className="text-xl text-gray-600 leading-relaxed max-w-2xl">
-                  <strong>Why not go further, faster? </strong>Work directly with D1 hockey mentors,
-                  use elite tools across every part of the game, and follow a personalized system
-                  built around you — so you can finally become the player you know you&apos;re
-                  capable of being.
+                  <strong>Why not go further, faster? </strong>Work directly with D1 hockey mentors
+                  who identify what&apos;s holding your game back and build a personalized plan
+                  around you — so your confidence, IQ, and real ability show up consistently in
+                  games.
                 </p>
               </div>
               <div className="flex flex-col sm:flex-row gap-4">
@@ -242,6 +243,7 @@ export default function HomePage() {
         </div>
       </section>
 
+      <HowYouImprove />
       <ValuePropSection />
       <TestimonialsSection />
       <HowItWorksSection />

--- a/src/components/layout/home/how-you-improve.tsx
+++ b/src/components/layout/home/how-you-improve.tsx
@@ -17,10 +17,27 @@ export function HowYouImprove() {
     },
   ]
 
+  // TODO(luke): Keep these accents in sync with the homepage brand palette as we iterate.
+  const sectionAccentClasses = {
+    haloPrimary: 'bg-[#0891B2]/10',
+    haloSecondary: 'bg-[#8B5CF6]/10',
+    circleBorder: 'border-[#0891B2]/30',
+    circleGlow: 'from-[#0891B2]/8 to-[#8B5CF6]/8',
+  }
+
   return (
-    <section className="relative bg-[#f8f9fa] py-24 md:py-32 lg:py-40">
-      <div className="mx-auto max-w-6xl px-6">
-        <h2 className="text-center text-4xl font-semibold tracking-tight text-[#1a1a2e] md:text-5xl lg:text-6xl">
+    <section className="relative overflow-hidden bg-gradient-to-b from-white via-gray-50 to-white py-24 md:py-32 lg:py-40">
+      <div className="pointer-events-none absolute inset-0">
+        <div
+          className={`absolute -top-24 -left-20 h-72 w-72 rounded-full blur-3xl ${sectionAccentClasses.haloPrimary}`}
+        />
+        <div
+          className={`absolute -bottom-24 -right-20 h-72 w-72 rounded-full blur-3xl ${sectionAccentClasses.haloSecondary}`}
+        />
+      </div>
+
+      <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 className="text-center text-4xl font-semibold tracking-tight text-gray-900 md:text-5xl lg:text-6xl">
           How You Improve
         </h2>
 
@@ -28,15 +45,27 @@ export function HowYouImprove() {
           <div className="hidden md:block">
             <div className="relative mx-auto h-[520px] w-full max-w-3xl lg:h-[540px] lg:max-w-[860px]">
               <div className="absolute left-1/2 top-0 -translate-x-1/2">
-                <Circle title={outcomes[0].title} description={outcomes[0].description} />
+                <Circle
+                  title={outcomes[0].title}
+                  description={outcomes[0].description}
+                  accentClasses={sectionAccentClasses}
+                />
               </div>
 
               <div className="absolute bottom-0 left-0 lg:left-[50px]">
-                <Circle title={outcomes[1].title} description={outcomes[1].description} />
+                <Circle
+                  title={outcomes[1].title}
+                  description={outcomes[1].description}
+                  accentClasses={sectionAccentClasses}
+                />
               </div>
 
               <div className="absolute bottom-0 right-0 lg:right-[50px]">
-                <Circle title={outcomes[2].title} description={outcomes[2].description} />
+                <Circle
+                  title={outcomes[2].title}
+                  description={outcomes[2].description}
+                  accentClasses={sectionAccentClasses}
+                />
               </div>
             </div>
           </div>
@@ -48,6 +77,7 @@ export function HowYouImprove() {
                   title={outcomes[0].title}
                   description={outcomes[0].description}
                   size="small"
+                  accentClasses={sectionAccentClasses}
                 />
               </div>
 
@@ -56,6 +86,7 @@ export function HowYouImprove() {
                   title={outcomes[1].title}
                   description={outcomes[1].description}
                   size="small"
+                  accentClasses={sectionAccentClasses}
                 />
               </div>
 
@@ -64,6 +95,7 @@ export function HowYouImprove() {
                   title={outcomes[2].title}
                   description={outcomes[2].description}
                   size="small"
+                  accentClasses={sectionAccentClasses}
                 />
               </div>
             </div>
@@ -74,14 +106,23 @@ export function HowYouImprove() {
   )
 }
 
+type AccentClasses = {
+  haloPrimary: string
+  haloSecondary: string
+  circleBorder: string
+  circleGlow: string
+}
+
 function Circle({
   title,
   description,
   size = 'default',
+  accentClasses,
 }: {
   title: string
   description: string
   size?: 'default' | 'small'
+  accentClasses: AccentClasses
 }) {
   const sizeClasses =
     size === 'small'
@@ -89,13 +130,18 @@ function Circle({
       : 'h-[280px] w-[280px] lg:h-[320px] lg:w-[320px]'
 
   return (
-    <div
-      className={`${sizeClasses} flex flex-col items-center justify-center rounded-full border-2 border-[#5bb5b0]/60 bg-white/70 p-8 text-center shadow-sm backdrop-blur-sm lg:border-[2.5px] lg:border-[#4fa8a3]/65`}
-    >
-      <h3 className="text-lg font-semibold leading-tight tracking-tight text-[#1a1a2e] lg:text-xl">
-        {title}
-      </h3>
-      <p className="mt-3 text-sm leading-relaxed text-[#5a5a6e] lg:text-[17px]">{description}</p>
+    <div className="relative">
+      <div
+        className={`pointer-events-none absolute inset-0 rounded-full bg-gradient-to-br blur-xl ${accentClasses.circleGlow}`}
+      />
+      <div
+        className={`${sizeClasses} relative flex flex-col items-center justify-center rounded-full border bg-white p-8 text-center shadow-md backdrop-blur-sm lg:border-[2.5px] ${accentClasses.circleBorder}`}
+      >
+        <h3 className="text-lg font-semibold leading-tight tracking-tight text-gray-900 lg:text-xl">
+          {title}
+        </h3>
+        <p className="mt-3 text-sm leading-relaxed text-gray-600 lg:text-[17px]">{description}</p>
+      </div>
     </div>
   )
 }

--- a/src/components/layout/home/how-you-improve.tsx
+++ b/src/components/layout/home/how-you-improve.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+export function HowYouImprove() {
+  const outcomes = [
+    {
+      title: 'Hockey IQ',
+      description: 'Play your position more effectively so your decisions create more impact',
+    },
+    {
+      title: 'Confidence and Freedom',
+      description:
+        'Play to your full ability under pressure and build the mental resilience to thrive.',
+    },
+    {
+      title: 'In-Game Results',
+      description: 'Turn your growth into measurable results in games.',
+    },
+  ]
+
+  return (
+    <section className="relative bg-[#f8f9fa] py-24 md:py-32 lg:py-40">
+      <div className="mx-auto max-w-6xl px-6">
+        <h2 className="text-center text-4xl font-semibold tracking-tight text-[#1a1a2e] md:text-5xl lg:text-6xl">
+          How You Improve
+        </h2>
+
+        <div className="relative mt-20 md:mt-28 lg:mt-24">
+          <div className="hidden md:block">
+            <div className="relative mx-auto h-[520px] w-full max-w-3xl lg:h-[540px] lg:max-w-[860px]">
+              <div className="absolute left-1/2 top-0 -translate-x-1/2">
+                <Circle title={outcomes[0].title} description={outcomes[0].description} />
+              </div>
+
+              <div className="absolute bottom-0 left-0 lg:left-[50px]">
+                <Circle title={outcomes[1].title} description={outcomes[1].description} />
+              </div>
+
+              <div className="absolute bottom-0 right-0 lg:right-[50px]">
+                <Circle title={outcomes[2].title} description={outcomes[2].description} />
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col items-center md:hidden">
+            <div className="relative h-[680px] w-full max-w-[320px]">
+              <div className="absolute left-1/2 top-0 -translate-x-1/2">
+                <Circle
+                  title={outcomes[0].title}
+                  description={outcomes[0].description}
+                  size="small"
+                />
+              </div>
+
+              <div className="absolute left-1/2 top-[200px] -translate-x-1/2">
+                <Circle
+                  title={outcomes[1].title}
+                  description={outcomes[1].description}
+                  size="small"
+                />
+              </div>
+
+              <div className="absolute left-1/2 top-[400px] -translate-x-1/2">
+                <Circle
+                  title={outcomes[2].title}
+                  description={outcomes[2].description}
+                  size="small"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function Circle({
+  title,
+  description,
+  size = 'default',
+}: {
+  title: string
+  description: string
+  size?: 'default' | 'small'
+}) {
+  const sizeClasses =
+    size === 'small'
+      ? 'h-[260px] w-[260px]'
+      : 'h-[280px] w-[280px] lg:h-[320px] lg:w-[320px]'
+
+  return (
+    <div
+      className={`${sizeClasses} flex flex-col items-center justify-center rounded-full border-2 border-[#5bb5b0]/60 bg-white/70 p-8 text-center shadow-sm backdrop-blur-sm lg:border-[2.5px] lg:border-[#4fa8a3]/65`}
+    >
+      <h3 className="text-lg font-semibold leading-tight tracking-tight text-[#1a1a2e] lg:text-xl">
+        {title}
+      </h3>
+      <p className="mt-3 text-sm leading-relaxed text-[#5a5a6e] lg:text-[17px]">{description}</p>
+    </div>
+  )
+}

--- a/src/components/layout/home/how-you-improve.tsx
+++ b/src/components/layout/home/how-you-improve.tsx
@@ -15,7 +15,7 @@ export function HowYouImprove() {
       title: 'In-Game Results',
       description: 'Turn your growth into measurable results in games.',
     },
-  ]
+  ] as const
 
   // TODO(luke): Keep these accents in sync with the homepage brand palette as we iterate.
   const sectionAccentClasses = {

--- a/src/components/layout/home/index.tsx
+++ b/src/components/layout/home/index.tsx
@@ -37,24 +37,24 @@ const valuePropItems = [
   },
   {
     icon: TrendingUp,
-    title: 'All-Around Development',
-    strong: "We don't just focus on one part of the game.",
+    title: 'Strategic Development',
+    strong: "Hockey performance isn’t built from one category alone.",
     description:
-      'High-level support and tools across every side of performance — training, nutrition, mindset, and hockey IQ — all built to work together in one complete system.',
+      'We have the tools and expertise across training, mindset, hockey IQ, and more — and apply the right pieces based on what your game actually needs most.',
   },
   {
     icon: User,
-    title: 'Personalized To You',
+    title: 'Personalized to You',
     strong: "This isn't a one-size-fits-all program.",
     description:
-      'Everything is built around your game and goals. We figure out what will get you the best results and build a personalized plan designed around you.',
+      'Everything is built around your game and goals. We identify what will create the biggest difference in your game and build a personalized plan around it.',
   },
   {
     icon: Trophy,
-    title: 'Network of Experts',
-    strong: 'A team of specialists behind every player.',
+    title: 'Built With Experts',
+    strong: 'Built with experts operating at the highest levels.',
     description:
-      'Our system blends insights from D1 strength coaches, NHL-level skill coaches, sports scientists, and performance experts — all working together to achieve your hockey goals.',
+      'Our development process and training systems are built alongside an Olympic sports performance doctor, NHL nutritionists, D1 strength coaches, and elite skill specialists.',
   },
 ]
 
@@ -138,29 +138,22 @@ export function NextStepsSection() {
     {
       step: 1,
       title: 'Free Strategy Call',
-      description: "Tell us where you're at, what you've tried, and what goals you're chasing.",
+      description: "We learn where you're at, what you've tried, and where you want to go.",
       icon: Users,
-      details: ['Goal-Based Matching', 'Personality Fit', 'Position-Specific Pairing'],
     },
     {
       step: 2,
-      title: 'Your Game Plan',
+      title: 'Get Matched',
       description:
-        "We'll build your player profile, set clear priorities, and pair you with the right D1 mentor for your path.",
+        "If it's a fit, we pair you with the right D1 mentor and the right path for your game.",
       icon: Target,
-      details: [
-        '1-on-1 Private Mentorship',
-        'Performance-Driven Resources',
-        'Consistent Progress Tracking',
-      ],
     },
     {
       step: 3,
       title: 'Start Producing Results',
       description:
-        "Unlock new opportunities, climb levels faster, and do it with guidance from people who've already made it there.",
+        'You begin making high-impact improvements that show up in games.',
       icon: Award,
-      details: ['Apply D1 Strategy', 'Use What Works', 'Turn Knowledge Into Results'],
     },
   ]
 
@@ -237,18 +230,6 @@ export function NextStepsSection() {
                     {item.description}
                   </p>
 
-                  {/* Feature list */}
-                  <div className="space-y-2 w-full max-w-[240px] relative z-10">
-                    {item.details.map((detail, detailIndex) => (
-                      <div
-                        key={detailIndex}
-                        className="flex items-center text-xs text-gray-600 font-medium"
-                      >
-                        <CheckCircle className="h-3.5 w-3.5 text-[#0891B2] mr-2 flex-shrink-0" />
-                        <span>{detail}</span>
-                      </div>
-                    ))}
-                  </div>
                 </div>
 
                 {/* Arrow for mobile */}
@@ -293,14 +274,14 @@ export function WhatYouGetEveryMonth() {
 
   const features = [
     {
-      title: 'Private Video Analysis Sessions',
+      title: 'Video Analysis Sessions',
       description:
-        'Private 1-on-1 game analysis with a D1+ mentor to improve hockey IQ and decision-making on the ice.',
+        '1-on-1 breakdowns with a D1 mentor to improve your hockey IQ and in-game impact.',
     },
     {
-      title: 'Mental & Strategy Sessions',
+      title: 'Mental Performance Sessions',
       description:
-        'Work 1-on-1 with your mentor on the mental side of the game to build confidence and guide overall development strategy.',
+        '1-on-1 sessions to strengthen confidence, build mental resilience, and guide your long-term development.',
     },
     {
       title: 'Personalized Development Plans',
@@ -310,7 +291,7 @@ export function WhatYouGetEveryMonth() {
     {
       title: 'The Complete Performix System',
       description:
-        'A decade of elite development tools compressed into one system — from hockey IQ, mindset, skill development, speed, strength, development strategy, and more.',
+        'Access to our full library of development tools and lessons across hockey IQ, mindset, training, skill, and recruitment — built to accelerate your progress in every phase of the game.',
     },
     {
       title: 'Smart Calendar System',
@@ -533,22 +514,22 @@ export function FAQSection() {
     {
       question: 'What is Performix?',
       answer:
-        'Performix is a high-performance development platform built by D1/pro athletes and top experts—performance coaches, specialists, and experienced team coaches. You get paired with your own personal D1 mentor and gain access to elite tools: custom training, nutrition, mindset strategies, video breakdowns, recruiting support, and a proven system designed to accelerate your development.',
+        'Performix is changing the way serious hockey players develop by helping them unlock more of their full ability in games. You work 1-on-1 with a Division I mentor who analyzes your game, identifies what\'s limiting you, and builds a plan around the adjustments that will make the biggest difference. We combine mentorship, hockey IQ development, and mental performance work into one clear system built to move your game forward.',
     },
     {
       question: 'Who is Performix for?',
       answer:
-        'Performix is for driven hockey players (typically ages 13-18) looking to develop faster, train smarter, and reach the next level—whether that is prep, juniors, or Division 1.',
+        "Performix is for serious hockey players (typically 13–18) who know they're capable of more but aren't consistently showing it in games. It's built for players who want structured guidance, high-level mentorship, and a clear development path toward prep, junior, NCAA, or higher levels.",
     },
     {
       question: 'What do I get with Performix?',
       answer:
-        'Depending on your package, you get matched with a personal mentor and unlock full access to the Performix system—including custom development plans, biweekly Zoom calls, goal-setting support, private video feedback, and unlimited mentor access. You will also get the full course, nutrition tools, mindset strategies, and recruiting guidance tailored to your game.',
+        'What you receive depends on your package, but every athlete gets direct support from a Division I mentor, 1-on-1 video analysis and mental sessions, a personalized development plan, and full access to the Performix system and tools. Higher tiers include more sessions and deeper customization, but the focus is always the same: real in-game improvement.',
     },
     {
       question: 'How do I get started?',
       answer:
-        'Book a free Zoom call so we can learn about your goals and pair you with the right mentor. From there, you\'ll unlock your tools, schedule your sessions, and start making real progress.',
+        "Book a free strategy call. We'll learn about your goals, situation, and development needs. If it's a fit, we'll match you with the right mentor and package to move your game forward.",
     },
     {
       question: "What's coming next on Performix?",
@@ -616,13 +597,13 @@ export function HowItWorksSection() {
       number: "02",
       title: "High-impact improvement sessions",
       description:
-        "Through 1-on-1 video analysis and focused mental and development sessions, D1 mentors show you what's holding your game back and what to do to create more impact on the ice",
+        "Through 1-on-1 video analysis and focused mental sessions, D1 mentors show you what's holding your game back and what to do to create more impact on the ice",
     },
     {
       number: "03",
       title: "Build a clear development plan",
       description:
-        "Based on what we find, we choose the few specific things that will make the biggest difference in your game and turn them into a clear, simple plan you know how to follow.",
+        "Based on what we find, we choose the specific things that will make the biggest difference in your game and turn them into a clear, simple plan you know how to follow.",
     },
     {
       number: "04",


### PR DESCRIPTION
## Why
Implement approved homepage updates from Matteo's "NEW WEB CHANGES" doc and add the new v0 section to improve messaging clarity and conversion.

## What Changed
- Added new `How You Improve` section component and inserted it below the homepage video.
- Updated homepage intro hero paragraph copy.
- Updated Performix Advantage card copy and labels.
- Updated "Your Next 3 Moves" card copy (removed point-form detail rows).
- Updated "What you get every month..." feature copy.
- Updated FAQ copy used in both homepage FAQ section and homepage JSON-LD FAQ data.

## Files
- `src/app/(frontend)/(browse)/page.tsx`
- `src/components/layout/home/index.tsx`
- `src/components/layout/home/how-you-improve.tsx`

## v0 Integration Notes
- Source: pasted v0 snippet from Matteo
- Adaptations made: extracted into `src/components/layout/home/how-you-improve.tsx`, imported into homepage, and placed between video section and `ValuePropSection`.

## QA
- [x] Desktop checked (local preview)
- [x] Mobile checked (responsive layout included in component)
- [x] No console/build errors blocking render
- [x] Lint passed (`pnpm lint`)

## Risk + Rollback
- Risk: Low (copy + section placement changes on homepage only)
- Rollback: revert this PR commit
