### PR TITLE
fix: remove default 10-doc limit on join fields (volumes capped at 10)

### DIFF
--- a/src/payload/collections/Modules/index.ts
+++ b/src/payload/collections/Modules/index.ts
@@ -101,6 +101,7 @@ const Modules: CollectionConfig = {
               on: 'module',
               label: 'Volumes',
               collection: VOLUMES_SLUG,
+              defaultLimit: 0,
             },
             {
               name: 'lessons',
@@ -108,6 +109,7 @@ const Modules: CollectionConfig = {
               on: 'module',
               label: 'Lessons',
               collection: LESSONS_SLUG,
+              defaultLimit: 0,
             },
           ],
         },

--- a/src/payload/collections/Volumes/index.ts
+++ b/src/payload/collections/Volumes/index.ts
@@ -101,6 +101,7 @@ const Volumes: CollectionConfig = {
               on: 'volume',
               label: 'Lessons',
               collection: LESSONS_SLUG,
+              defaultLimit: 0,
             },
           ],
         },


### PR DESCRIPTION
## Problem

The Mental Game module has 12 volumes in admin, but the lab only shows 10.

## Root Cause

PayloadCMS `join` fields have a **default limit of 10 documents**. Since the `volumes` and `lessons` fields on Modules (and `lessons` on Volumes) use `type: 'join'` without specifying a `defaultLimit`, Payload silently caps the results at 10.

This affects:
- **Module detail page** (`/lab/module/[slug]`) — calls `getModuleBySlug()` with `depth: 4`, which populates the volumes join → capped at 10
- **Module completion tracking** — `getModuleCompletion()` reads lessons from the join → could undercount if >10 lessons

## What's NOT affected
- **Lab homepage sections** — `LabSection` uses a polymorphic relationship field (`content`), not joins. It fetches sections at `depth: 0` then renders individual cards by ID, bypassing the join entirely.
- **Direct volume/lesson fetches** — `getVolumeBySlug`, `getLessonsByVolumeId`, etc. use explicit `payload.find()` with `limit: 100`, not joins.

## Fix

Added `defaultLimit: 0` to all three join fields, which tells Payload to return **all** related documents:

- `Modules → volumes` join
- `Modules → lessons` join  
- `Volumes → lessons` join

## Files Changed
- `src/payload/collections/Modules/index.ts`
- `src/payload/collections/Volumes/index.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change that only affects how many related docs Payload returns for `join` fields; main impact is potentially larger query payloads when modules/volumes have many children.
> 
> **Overview**
> Removes PayloadCMS’s implicit 10-document cap on admin/API `join` relationships by setting `defaultLimit: 0` on the `Modules` joins (`volumes`, `lessons`) and the `Volumes` join (`lessons`).
> 
> This ensures module/volume reads can return *all* related children instead of silently truncating at 10.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d046baedb495170a68298b1d62feb74a404a053. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->